### PR TITLE
lambdaの更新完了を待ってタスク完了とする

### DIFF
--- a/aws/lambda_function_update/README.md
+++ b/aws/lambda_function_update/README.md
@@ -19,6 +19,7 @@ Lambda関数のDockerイメージを更新するComposite Actionです。
 | `function_name` | ✓ | - | Lambda関数名 |
 | `image` | ✓ | - | コンテナイメージのURI (タグを除く) |
 | `tag` | | `main` | イメージタグ |
+| `wait_for_update` | | `false` | 更新完了を待つかどうか |
 
 ## 使用例
 

--- a/aws/lambda_function_update/action.yml
+++ b/aws/lambda_function_update/action.yml
@@ -20,4 +20,5 @@ runs:
         aws lambda update-function-code \
           --function-name ${{ inputs.function_name }} \
           --image-uri ${{ inputs.image }}:${{ inputs.tag }}
+        aws lambda wait function-updated --function-name ${{ inputs.function_name }}
       shell: bash

--- a/aws/lambda_function_update/action.yml
+++ b/aws/lambda_function_update/action.yml
@@ -11,6 +11,9 @@ inputs:
     required: true
   function_name:
     required: true
+  wait_for_update:
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -20,5 +23,9 @@ runs:
         aws lambda update-function-code \
           --function-name ${{ inputs.function_name }} \
           --image-uri ${{ inputs.image }}:${{ inputs.tag }}
+      shell: bash
+    - name: wait lambda function ${{ inputs.function_name }} updated
+      if: inputs.wait_for_update == 'true'
+      run: |
         aws lambda wait function-updated --function-name ${{ inputs.function_name }}
       shell: bash


### PR DESCRIPTION
# 概要

## 変更目的
<!-- 変更の目的を簡潔に記述してください -->

lambda-update-function実行後に 反映されたlambdaにヘルスチェックを行うようなパターンがあり
lambda update-function-code完了とlambdaの更新完了まで待つ処理を追加しました


## 変更内容
<!-- 変更の概要を簡潔に記述してください -->

lambda-function-update内で  `aws lambda update-function-code` 実行後に `aws lambda wait function-updated` を追加しました
 
# 関連文書
<!-- このPRが関連するissueや、関係者と会話しているslackスレッドなどを記載してください。 -->

# レビューして欲しい人とレビュー観点
<!--
- レビューして欲しい人を簡単に記載してください
- セルフマージする場合は省略可
-->

@shoe116 @2k0ri @eijisakato 

共通アクションとしてwaitが必要かどうかの観点で不要であればcloseするのでコメントいただけると幸いです

# Merge前に確認すること

> [!WARNING]
> このPRをマージすると、このリポジトリのアクションを利用しているすべてのリポジトリのワークフローが更新されます。

## 依存するPRやデータ更新
<!-- 
- このPRが依存するリリースやユーザコミュニケーションがあれば記載してください
- 依存するPRやデータ更新がない場合は「なし」と明記
-->
