### PR TITLE
fix: claude-code-actionをv1.0.88にダウングレード（symlinkバグ回避）

### DIFF
--- a/claude-code/pr-review/action.yml
+++ b/claude-code/pr-review/action.yml
@@ -6,10 +6,6 @@ inputs:
   anthropic_api_key:
     description: 'Anthropic API Key'
     required: true
-  timeout_minutes:
-    description: 'タイムアウト時間（分）'
-    required: false
-    default: '60'
   allowed_bots:
     description: '許可するボットのリスト（カンマ区切り）'
     required: false
@@ -29,8 +25,10 @@ runs:
 
     - name: Run Claude PR Action
       # よりセキュアに運用するため、v1 と記載せずにパッチバージョンまで明記している
-      uses: anthropics/claude-code-action@v1.0.101
+      # v1.0.89以降、SENSITIVE_PATHSにsymlinkが含まれるとcpSyncがENOENTでクラッシュするバグあり
+      # see: https://github.com/anthropics/claude-code-action/issues/1187
+      # 修正PR(#1186)がマージされたらバージョンを上げること
+      uses: anthropics/claude-code-action@v1.0.88
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
-        timeout_minutes: ${{ inputs.timeout_minutes }}
         allowed_bots: ${{ inputs.allowed_bots }}


### PR DESCRIPTION
# 概要

## 変更目的
claude-code-action v1.0.89以降に存在するsymlinkバグ（[anthropics/claude-code-action#1187](https://github.com/anthropics/claude-code-action/issues/1187)）を回避する。

SENSITIVE_PATHS（`CLAUDE.md`等）にsymlinkが含まれるリポジトリでPRレビューを実行すると、`cpSync`が`ENOENT: no such file or directory, symlink`でクラッシュする。


## 変更内容
- `anthropics/claude-code-action` を `v1.0.101` → `v1.0.88` にダウングレード
- v1.0.101で廃止済みの `timeout_minutes` inputを削除
- バグのissueリンクと修正PR(#1186)マージ後にバージョンを上げる旨のコメントを追記

# 関連文書
- バグissue: https://github.com/anthropics/claude-code-action/issues/1187
- 修正PR: https://github.com/anthropics/claude-code-action/pull/1186

# レビューして欲しい人とレビュー観点
- セルフマージ

# Merge前に確認すること

> [!WARNING]
> このPRをマージすると、このリポジトリのアクションを利用しているすべてのリポジトリのワークフローが更新されます。

## 依存するPRやデータ更新
なし