### PR TITLE
feat(claude-code/pr-review): AGENTS.mdからCLAUDE.mdを自動生成

### DIFF
--- a/claude-code/pr-review/README.md
+++ b/claude-code/pr-review/README.md
@@ -78,6 +78,19 @@ jobs:
 
 - `ANTHROPIC_API_KEY`: Anthropic APIキー（Organization secretsで設定推奨）
 
+## CLAUDE.md / AGENTS.md の取り扱い
+
+チェックアウト後、リポジトリルートに対して以下のチェックを行います:
+
+1. `CLAUDE.md` が `AGENTS.md` へのシンボリックリンクの場合: シンボリックリンクを削除して `AGENTS.md` の実体をコピーします
+2. `CLAUDE.md` が存在する場合: そのまま使用します
+3. `CLAUDE.md` が無く `AGENTS.md` が存在する場合: `AGENTS.md` を `CLAUDE.md` としてコピーします
+4. どちらも存在しない場合: エラーメッセージを出力してActionを失敗させます
+
+`AGENTS.md` を使っているリポジトリでも、ファイルを重複管理せずに Claude PR Review を利用できるようにするための挙動です。
+
+なお、シンボリックリンクを実体コピーに置き換えているのは、`claude-code-action` v1.0.89 以降で `SENSITIVE_PATHS` にsymlinkが含まれると `cpSync` が `ENOENT` でクラッシュするバグがあるためです（[anthropics/claude-code-action#1187](https://github.com/anthropics/claude-code-action/issues/1187)）。
+
 ## セキュリティに関する注意事項
 
 このActionでは、`anthropics/claude-code-action` のバージョンを `v1` のようなメジャーバージョン指定ではなく、`v1.0.29` のようにパッチバージョンまで明記しています。これは、よりセキュアに運用するための措置です。

--- a/claude-code/pr-review/action.yml
+++ b/claude-code/pr-review/action.yml
@@ -23,6 +23,27 @@ runs:
       with:
         fetch-depth: ${{ inputs.checkout_fetch_depth }}
 
+    - name: Ensure CLAUDE.md exists (copy from AGENTS.md if needed)
+      # CLAUDE.mdがAGENTS.mdへのsymlinkだった場合、symlinkを削除して実体のコピーに置き換える
+      # claude-code-action v1.0.89以降、SENSITIVE_PATHSにsymlinkが含まれると
+      # cpSyncがENOENTでクラッシュするバグがあるための回避
+      # see: https://github.com/anthropics/claude-code-action/issues/1187
+      shell: bash
+      run: |
+        if [ -L CLAUDE.md ] && [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]; then
+          echo "CLAUDE.md is a symlink to AGENTS.md. Replacing with a copy."
+          rm CLAUDE.md
+          cp AGENTS.md CLAUDE.md
+        elif [ -e CLAUDE.md ]; then
+          echo "CLAUDE.md found."
+        elif [ -e AGENTS.md ]; then
+          echo "CLAUDE.md not found. Copying AGENTS.md to CLAUDE.md."
+          cp AGENTS.md CLAUDE.md
+        else
+          echo "::error::Neither CLAUDE.md nor AGENTS.md was found in the repository root. Please add one of them to use Claude PR Review."
+          exit 1
+        fi
+
     - name: Run Claude PR Action
       # よりセキュアに運用するため、v1 と記載せずにパッチバージョンまで明記している
       # v1.0.89以降、SENSITIVE_PATHSにsymlinkが含まれるとcpSyncがENOENTでクラッシュするバグあり


### PR DESCRIPTION
# 概要

## 変更目的
`claude-code/pr-review` Actionを `AGENTS.md` を運用しているリポジトリでも、ファイルを重複管理せずに利用できるようにする。
また、`claude-code-action` v1.0.89以降で `CLAUDE.md` が symlink の場合に `cpSync` が `ENOENT` でクラッシュする問題（[anthropics/claude-code-action#1187](https://github.com/anthropics/claude-code-action/issues/1187)）を回避する。

## 変更内容
`claude-code/pr-review/action.yml` にチェックアウト後の処理ステップを追加し、リポジトリルートに対して以下の挙動を行うようにした:

1. `CLAUDE.md` が `AGENTS.md` への symlink の場合: symlink を削除し、`AGENTS.md` の実体を `CLAUDE.md` としてコピー（#1187 回避）
2. `CLAUDE.md` が存在する場合: そのまま使用
3. `CLAUDE.md` が無く `AGENTS.md` が存在する場合: `AGENTS.md` を `CLAUDE.md` としてコピー
4. どちらも存在しない場合: `::error::` を出力して Action を失敗させる

`claude-code/pr-review/README.md` にも上記挙動を追記。

# 関連文書
- [anthropics/claude-code-action#1187](https://github.com/anthropics/claude-code-action/issues/1187)

# レビューして欲しい人とレビュー観点
<!--
- レビューして欲しい人を簡単に記載してください
- セルフマージする場合は省略可
-->

# Merge前に確認すること

> [!WARNING]
> このPRをマージすると、このリポジトリのアクションを利用しているすべてのリポジトリのワークフローが更新されます。

## 依存するPRやデータ更新
なし