### PR TITLE
chore(deps): bump anthropics/claude-code-action to v1.0.123

### DIFF
--- a/claude-code/pr-review/action.yml
+++ b/claude-code/pr-review/action.yml
@@ -25,10 +25,7 @@ runs:
 
     - name: Run Claude PR Action
       # よりセキュアに運用するため、v1 と記載せずにパッチバージョンまで明記している
-      # v1.0.89以降、SENSITIVE_PATHSにsymlinkが含まれるとcpSyncがENOENTでクラッシュするバグあり
-      # see: https://github.com/anthropics/claude-code-action/issues/1187
-      # 修正PR(#1186)がマージされたらバージョンを上げること
-      uses: anthropics/claude-code-action@v1.0.119
+      uses: anthropics/claude-code-action@v1.0.123
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         allowed_bots: ${{ inputs.allowed_bots }}


### PR DESCRIPTION
# 概要

## 変更目的
<!-- 変更の目的を簡潔に記述してください -->
`anthropics/claude-code-action` を `v1.0.119` から `v1.0.123` にバージョンアップする。

issue [#1187](https://github.com/anthropics/claude-code-action/issues/1187) (`SENSITIVE_PATHS` に symlink が含まれると `cpSync` が ENOENT でクラッシュするバグ) の修正PR [#1186](https://github.com/anthropics/claude-code-action/pull/1186) が v1.0.123 に取り込まれたため、ワークアラウンド待ちを示すコメントを削除する。

## 変更内容
<!-- 変更の概要を簡潔に記述してください -->
- `claude-code/pr-review/action.yml` の `anthropics/claude-code-action` を `v1.0.119` → `v1.0.123` にバンプ
- 修正取り込み待ちを示すコメント3行を削除
- セキュリティ目的でパッチバージョンまでピン留めしているコメントは維持

# 関連文書
<!-- このPRが関連するissueや、関係者と会話しているslackスレッドなどを記載してください。 -->
- https://github.com/anthropics/claude-code-action/issues/1187
- https://github.com/anthropics/claude-code-action/pull/1186
- https://github.com/anthropics/claude-code-action/releases/tag/v1.0.123

# レビューして欲しい人とレビュー観点
<!--
- レビューして欲しい人を簡単に記載してください
- セルフマージする場合は省略可
-->

# Merge前に確認すること

> [!WARNING]
> このPRをマージすると、このリポジトリのアクションを利用しているすべてのリポジトリのワークフローが更新されます。

## 依存するPRやデータ更新
<!-- 
- このPRが依存するリリースやユーザコミュニケーションがあれば記載してください
- 依存するPRやデータ更新がない場合は「なし」と明記
-->
なし