### PR TITLE
ci: add OSV-Scanner Full Scan reusable workflow

### DIFF
--- a/.github/workflows/osv-scanner-full.yml
+++ b/.github/workflows/osv-scanner-full.yml
@@ -1,0 +1,13 @@
+name: OSV-Scanner Full Scan
+
+on:
+  workflow_call:
+
+permissions:
+  actions: read
+  security-events: write
+  contents: read
+
+jobs:
+  scan-full:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8

--- a/.github/workflows/osv-scanner-full.yml
+++ b/.github/workflows/osv-scanner-full.yml
@@ -42,3 +42,60 @@ jobs:
                 }
               ]
             }
+
+  create-issue:
+    needs: scan-full
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update OSV-Scanner issue
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const titlePrefix = '[OSV-Scanner]';
+            const issueTitle = `${titlePrefix} Vulnerabilities detected in daily scan`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = issues.find(
+              (i) => !i.pull_request && i.title.startsWith(titlePrefix)
+            );
+
+            const commentBody = `Re-detected on ${today}.\n\n[View run logs and SARIF artifact](${runUrl})`;
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: commentBody,
+              });
+              core.info(`Commented on existing issue #${existing.number}`);
+            } else {
+              const body = [
+                'OSV-Scanner detected vulnerabilities in this repository during the daily full scan.',
+                '',
+                `**First detected:** ${today}`,
+                `**Workflow run:** [View logs and SARIF artifact](${runUrl})`,
+                '',
+                'This issue will be re-used for subsequent detections (added as comments).',
+                'Close this issue after resolving all vulnerabilities; new failures will then create a fresh issue.',
+              ].join('\n');
+
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                body,
+              });
+              core.info(`Created issue #${created.number}`);
+            }

--- a/.github/workflows/osv-scanner-full.yml
+++ b/.github/workflows/osv-scanner-full.yml
@@ -2,6 +2,10 @@ name: OSV-Scanner Full Scan
 
 on:
   workflow_call:
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+        description: "Slack incoming webhook URL for vulnerability alerts"
 
 permissions:
   actions: read
@@ -11,3 +15,30 @@ permissions:
 jobs:
   scan-full:
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8
+    with:
+      upload-sarif: false
+      fail-on-vuln: true
+
+  notify-slack:
+    needs: scan-full
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on vulnerability
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":rotating_light: OSV vulnerabilities detected in ${{ github.repository }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":rotating_light: *OSV-Scanner found vulnerabilities*\n*Repository:* `${{ github.repository }}`\n*Workflow:* `${{ github.workflow }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run logs and SARIF artifact>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/osv-scanner-full.yml
+++ b/.github/workflows/osv-scanner-full.yml
@@ -3,9 +3,9 @@ name: OSV-Scanner Full Scan
 on:
   workflow_call:
     secrets:
-      SLACK_WEBHOOK_URL:
+      OSV_SCANNER_SLACK_WEBHOOK_URL:
         required: true
-        description: "Slack incoming webhook URL for vulnerability alerts"
+        description: "Slack incoming webhook URL for OSV-Scanner vulnerability alerts"
 
 permissions:
   actions: read
@@ -27,7 +27,7 @@ jobs:
       - name: Notify Slack on vulnerability
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.OSV_SCANNER_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {


### PR DESCRIPTION
## 概要

各リポジトリで daily の OSV フルスキャンを行うための reusable workflow を追加する。脆弱性検出時に Slack 通知と GitHub Issue 作成の両方を行う。

## 背景

api-metric-service #107 で daily フルスキャンが導入されたが、現状は各リポジトリが直接 `google/osv-scanner-action` を参照している。横展開を考えると本リポジトリに集約して reusable workflow として提供し、各リポジトリは薄いラッパーから呼び出す形にしたい。

- scanner action のバージョン pin (`@v2.3.8`) を中央で一元管理できる
- wiring（permissions, オプション, 通知）の社内ポリシーも中央で更新可能
- Dependabot は既に `.github/workflows` をカバーしているので追加設定不要

## 通知設計

buffett-code-dev は **GitHub Team プラン**で GitHub Code Security (GHAS) を契約しておらず、Code Scanning（Security タブ）が private リポジトリで使えない。そのまま `upload-sarif: true` で動かすと private リポでは失敗する。また cron 失敗メールは「ワークフローファイルを最後にコミットした人」にしか届かないため、チームに気付ける形にする必要がある。

採用した通知経路：

| 経路 | 役割 |
|---|---|
| **Slack 通知** | セキュリティチームへの即時通知（横断把握） |
| **GitHub Issue 自動作成** | 該当リポジトリの maintainer への通知 + 対応トラッキング |

ジョブ構成：

- `scan-full`: 既存の `google/osv-scanner-action` reusable を `upload-sarif: false`, `fail-on-vuln: true` で呼ぶ
- `notify-slack`: 失敗時に Slack incoming webhook へ通知（`slackapi/slack-github-action@v3.0.3`）
- `create-issue`: 失敗時に GitHub Issue を作成 or コメント追記（`actions/github-script@v9.0.0`）

Issue は **タイトル prefix `[OSV-Scanner]` で deduplication**：
- 既存の OSV-Scanner Issue がオープン中 → コメント追記（重複防止）
- なければ新規作成
- クローズすれば「修正完了」、再検出時は新しい Issue が作られる

## 各リポジトリでの呼び出し例

```yaml
# .github/workflows/osv-full-scanner.yml
name: OSV-Scanner Full Scan
on:
  workflow_dispatch:
  schedule:
    - cron: "0 0 * * *"  # 毎日 09:00 JST
permissions:
  actions: read
  security-events: write
  contents: read
  issues: write
jobs:
  scan-full:
    uses: buffett-code-dev/github-actions/.github/workflows/osv-scanner-full.yml@main
    secrets: inherit
```

- `@main` 参照で中央更新を即時に全リポジトリへ反映
- `secrets: inherit` で Org Secret の `OSV_SCANNER_SLACK_WEBHOOK_URL` を引き渡す
- caller 側にも `issues: write` 権限が必要

## 事前準備（マージ前）

- [ ] Slack incoming webhook URL を Organization Secret `OSV_SCANNER_SLACK_WEBHOOK_URL` として登録
  - 通知先チャンネルは security alert 向けの専用チャンネルを推奨

## 動作確認方法

マージ後、テストリポジトリで上記ラッパーを workflow_dispatch から手動実行し以下を確認：
1. 脆弱性がない場合: `scan-full` 成功 → `notify-slack` / `create-issue` スキップ
2. 脆弱性がある場合: `scan-full` 失敗 → Slack 通知到着 + Issue 作成
3. 再実行: 既存 Issue にコメント追記される
4. Issue クローズ後の再実行: 新しい Issue が作成される

## 将来の発展

- GHAS（GitHub Code Security）を契約することになれば、`upload-sarif: true` に変更して Security タブ運用へ一斉移行可能。中央 reusable workflow を一箇所修正するだけで全リポジトリへ反映される。

## ref

- 既存の PR スキャン用 reusable workflow (`osv-scanner.yml`) はそのまま残す
- api-metric-service #107 のフルスキャン workflow は、このPRマージ後にラッパーへ差し替える別PRを作る予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)