### PR TITLE
label-stale-items: READMEサンプルのワークフロー名を items に修正

### DIFF
--- a/github/label-stale-items/README.md
+++ b/github/label-stale-items/README.md
@@ -28,7 +28,7 @@
 ### 基本的な使用方法 (定期実行)
 
 ```yaml
-name: Label stale issues
+name: Label stale items
 
 on:
   schedule:
@@ -73,7 +73,7 @@ jobs:
 ### 手動実行も可能にする
 
 ```yaml
-name: Label stale issues
+name: Label stale items
 
 on:
   schedule:


### PR DESCRIPTION
PRもデフォルト対象になったので、README使用例の `name: Label stale issues` を `name: Label stale items` に揃える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)