### PR TITLE
stale-items README: 使用例の cron を毎日→毎週月曜に変更

### DIFF
--- a/github/label-stale-items/README.md
+++ b/github/label-stale-items/README.md
@@ -34,7 +34,7 @@ name: Label stale items
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # 毎日0時に実行
+    - cron: '0 0 * * 1'  # 毎週月曜日に実行
 
 jobs:
   stale:
@@ -79,7 +79,7 @@ name: Label stale items
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1'
   workflow_dispatch:  # 手動実行を許可
 
 jobs:

--- a/github/manage-stale-items/README.md
+++ b/github/manage-stale-items/README.md
@@ -31,7 +31,7 @@ name: Manage stale items
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # 毎日0時に実行
+    - cron: '0 0 * * 1'  # 毎週月曜日に実行
 
 jobs:
   stale:
@@ -76,7 +76,7 @@ name: Manage stale items
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1'
   workflow_dispatch:  # 手動実行を許可
 
 jobs:


### PR DESCRIPTION
毎日実行は過剰なので、`manage-stale-items` / `label-stale-items` 両方の README サンプル cron を `0 0 * * 1`（毎週月曜）に揃える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)