### PR TITLE
[codex] Claude Code ActionのモデルをSonnet 4.6に固定

### DIFF
--- a/claude-code/pr-review/action.yml
+++ b/claude-code/pr-review/action.yml
@@ -29,3 +29,7 @@ runs:
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         allowed_bots: ${{ inputs.allowed_bots }}
+        settings: |
+          {
+            "model": "claude-sonnet-4-6"
+          }

--- a/claude-code/pr-review/action.yml
+++ b/claude-code/pr-review/action.yml
@@ -29,7 +29,5 @@ runs:
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         allowed_bots: ${{ inputs.allowed_bots }}
-        settings: |
-          {
-            "model": "claude-sonnet-4-6"
-          }
+        claude_args: |
+          --model claude-sonnet-4-6


### PR DESCRIPTION
# 概要

## 変更目的
Claude Code Actionで利用するモデルをClaude Sonnet 4.6に明示的に固定します。

## 変更内容
- `claude-code/pr-review/action.yml` の `anthropics/claude-code-action` 呼び出しに `claude_args` を追加
- Claude Code CLI引数として `--model claude-sonnet-4-6` を設定

# 関連文書
なし

# レビューして欲しい人とレビュー観点
セルフマージ想定です。

# Merge前に確認すること

> [!WARNING]
> このPRをマージすると、このリポジトリのアクションを利用しているすべてのリポジトリのワークフローが更新されます。

## 依存するPRやデータ更新
なし

## 動作確認
- `ruby -e 'require "yaml"; y=YAML.load_file("claude-code/pr-review/action.yml"); step=y.dig("runs", "steps").last; args=step.dig("with", "claude_args"); abort "unexpected claude_args: #{args.inspect}" unless args == "--model claude-sonnet-4-6\n"; abort "settings should not be present" if step.dig("with").key?("settings"); puts "claude_args OK"'`

## 補足
- Anthropic公式ドキュメントで、Claude Sonnet 4.6のClaude API IDが `claude-sonnet-4-6` であることを確認済みです。
- `anthropics/claude-code-action` v1.0 release notesでは、モデル選択は `claude_args` の CLI形式で指定する移行方針になっているため、`settings` ではなく `claude_args` にしています。