### PR TITLE
fix: configure-aws-credentials のタグを v プレフィックス付きに修正

### DIFF
--- a/aws/credentials/action.yml
+++ b/aws/credentials/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@6.1.3
+      uses: aws-actions/configure-aws-credentials@v6.1.3
       with:
         role-to-assume: ${{ inputs.role_to_assume }}
         aws-region: ${{ inputs.aws_region }}


### PR DESCRIPTION
## 変更目的

`aws-actions/configure-aws-credentials@6.1.3` が解決できず CI が失敗していたため、`v` プレフィックス付きの `@v6.1.3` に修正する。
今まで動いてたのに動かなくなった謎。


https://github.com/buffett-code-dev/ai-agent-service/actions/runs/28277267816
```
[docker_build_and_push](https://github.com/buffett-code-dev/ai-agent-service/actions/runs/28277267816/job/83787999536#step:1:32)
Unable to resolve action `aws-actions/configure-aws-credentials@6.1.3`, unable to find version `6.1.3`
```

## 変更内容

`aws/credentials/action.yml` の `@6.1.3` → `@v6.1.3`

## 関連文書
このマージがで`@v6.1.1 -> @6.1.3`に変えてる。
https://github.com/buffett-code-dev/github-actions/pull/99

## 依存するPRやデータ更新

なし

## マージ後にやること

なし